### PR TITLE
Add vrd api key to env

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,6 +10,8 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: set up r env
+        run: echo VRD_API = ${{ secrets.VRD_API }} > ~/.Renviron
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v1
       - name: Install dependencies

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -11,3 +11,11 @@ test_that("call_rd_api() returns the correct structure",{
     response <- call_vrd_api(test_url, "", api_key="test")
     expect_type(response, "list")
 })
+
+test_that("we can make api call with our key",{
+  result <- count_recall_by_make('Nissan')
+  expect_type(result, "list")
+})
+
+
+


### PR DESCRIPTION
Gets the api key that was added to github's env, and puts it into r's env
so we can test api calls with out having to skip or do anything dumb