### PR TITLE
update CICD workflows

### DIFF
--- a/.github/workflows/R-CMD-check-full.yaml
+++ b/.github/workflows/R-CMD-check-full.yaml
@@ -1,8 +1,9 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
-on: [push, pull_request]
+on:
+  workflow_dispatch:
 
-name: R-CMD-check
+name: R-CMD-check-full
 
 jobs:
   R-CMD-check:

--- a/.github/workflows/R-CMD-check-single.yaml
+++ b/.github/workflows/R-CMD-check-single.yaml
@@ -1,13 +1,16 @@
+# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
+# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
 on: [push, pull_request]
 
-name: test-coverage
+name: R-CMD-check-single
 
 jobs:
-  test-coverage:
+  R-CMD-check:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       VRD_API: ${{ secrets.VRD_API }}
+
     steps:
       - uses: actions/checkout@v2
 
@@ -31,9 +34,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("remotes"))
+          install.packages(c("remotes", "rcmdcheck"))
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
+        shell: Rscript {0}
+
+      - name: Check
+        run: |
+          options(crayon.enabled = TRUE)
+          rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
         shell: Rscript {0}
 
       - name: Test coverage


### PR DESCRIPTION
Currently we have CICD running R-CMD-check on 4 OS as well as an additional test coverage workflow, this results in 10 tests associated with a PR as it run for both push and pull. To avoid this number of tests, the CICD workflow files are updated as followed:
- modified the current workflow that runs R-CMD-check on 4 OS systems to only be triggered manually
- made a new R-CMD-check that only runs on Mac-OS and incorporated the test coverage workflow within it - this will run on both push and pull
- deleted the test-coverage workflow which is now redundant